### PR TITLE
Add support for specifying `tls_port`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type ConfigSchema struct {
 type RouteSchema struct {
 	Name                 string             `yaml:"name"`
 	Port                 *int               `yaml:"port"`
+	TLSPort              *int               `yaml:"tls_port"`
 	Tags                 map[string]string  `yaml:"tags"`
 	URIs                 []string           `yaml:"uris"`
 	RouteServiceUrl      string             `yaml:"route_service_url"`
@@ -60,7 +61,8 @@ type Config struct {
 
 type Route struct {
 	Name                 string
-	Port                 int
+	Port                 *int
+	TLSPort              *int
 	Tags                 map[string]string
 	URIs                 []string
 	RouteServiceUrl      string
@@ -154,10 +156,14 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 		errors.Add(fmt.Errorf("no name"))
 	}
 
-	if r.Port == nil {
+	if r.Port == nil && r.TLSPort == nil {
 		errors.Add(fmt.Errorf("no port"))
-	} else if *r.Port <= 0 {
+	}
+	if r.Port != nil && *r.Port <= 0 {
 		errors.Add(fmt.Errorf("invalid port: %d", *r.Port))
+	}
+	if r.TLSPort != nil && *r.TLSPort <= 0 {
+		errors.Add(fmt.Errorf("invalid tls_port: %d", *r.TLSPort))
 	}
 
 	if len(r.URIs) == 0 {
@@ -195,7 +201,8 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 
 	route := Route{
 		Name:                 r.Name,
-		Port:                 *r.Port,
+		Port:                 r.Port,
+		TLSPort:              r.TLSPort,
 		Tags:                 r.Tags,
 		URIs:                 r.URIs,
 		RouteServiceUrl:      r.RouteServiceUrl,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,14 @@ var _ = Describe("Config", func() {
 				},
 				{
 					Name:                 routeName1,
-					Port:                 &port1,
+					TLSPort:              &port1,
+					RegistrationInterval: registrationInterval1String,
+					URIs:                 []string{"my-other-app.my-domain.com"},
+				},
+				{
+					Name:                 routeName1,
+					Port:                 &port0,
+					TLSPort:              &port1,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
 				},
@@ -344,6 +351,19 @@ var _ = Describe("Config", func() {
 					Expect(c).To(BeNil())
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(`route "route-0"`))
+					Expect(err.Error()).To(ContainSubstring("no port"))
+				})
+			})
+			Context("when the port value is not provided", func() {
+				BeforeEach(func() {
+					configSchema.Routes[1].TLSPort = nil
+				})
+
+				It("returns an error", func() {
+					c, err := configSchema.ToConfig()
+					Expect(c).To(BeNil())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(`route "route-1"`))
 					Expect(err.Error()).To(ContainSubstring("no port"))
 				})
 			})

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -6,7 +6,12 @@ routes:
   uris: ["my-app.my-domain.com"]
   registration_interval: 20s
 - name: "route-1"
-  port: 3001
+  tls_port: 3001
+  uris: ["my-other-app.my-domain.com"]
+  registration_interval: 10s
+- name: "route-2"
+  port: 3000
+  tls_port: 3001
   uris: ["my-other-app.my-domain.com"]
   registration_interval: 10s
 message_bus_servers:

--- a/main_test.go
+++ b/main_test.go
@@ -122,10 +122,11 @@ var _ = Describe("Main", func() {
 		var receivedMessage string
 		Eventually(registered, 10*time.Second).Should(Receive(&receivedMessage))
 
+		i12345 := 12345
 		expectedRegistryMessage := messagebus.Message{
 			URIs: []string{"uri-1", "uri-2"},
 			Host: "127.0.0.1",
-			Port: 12345,
+			Port: &i12345,
 			Tags: map[string]string{"tag1": "val1", "tag2": "val2"},
 		}
 

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -30,7 +30,8 @@ type msgBus struct {
 type Message struct {
 	URIs              []string          `json:"uris"`
 	Host              string            `json:"host"`
-	Port              int               `json:"port"`
+	Port              *int              `json:"port,omitempty"`
+	TLSPort           *int              `json:"tls_port,omitempty"`
 	Tags              map[string]string `json:"tags"`
 	RouteServiceUrl   string            `json:"route_service_url,omitempty"`
 	PrivateInstanceId string            `json:"private_instance_id"`
@@ -101,6 +102,7 @@ func (m msgBus) SendMessage(subject string, host string, route config.Route, pri
 		URIs:              route.URIs,
 		Host:              host,
 		Port:              route.Port,
+		TLSPort:           route.TLSPort,
 		Tags:              route.Tags,
 		RouteServiceUrl:   route.RouteServiceUrl,
 		PrivateInstanceId: privateInstanceId,


### PR DESCRIPTION
`Gorouter` [recently added support](https://github.com/cloudfoundry/gorouter/commit/e95cf8b0310bca45d3fe4ba36ee165feef74ecc1#diff-3baf47c64847a8fb8aaa8cc2e088513b) for connecting to backends over TLS.

Allow specifying an optional `tls_port` via the `route-registrar` in-place of or in addition to a `port`.