### PR TITLE
Initial TCP routing support.

### DIFF
--- a/example_config/example.json
+++ b/example_config/example.json
@@ -27,6 +27,14 @@
       ],
       "registration_interval": "10s",
       "server_cert_domain_san": "my.internal.cert"
+    },
+    {
+        "type": "tcp",
+        "port": 5000,
+        "backend_ip": "10.0.1.1",
+        "backend_port": 15000,
+        "router_group": "some-router-group",
+        "registration_interval": "10s"
     }
   ],
   "message_bus_servers": [
@@ -40,5 +48,11 @@
       "user": "another-user",
       "password": "another-password"
     }
-  ]
+  ],
+  "routing_api": {
+    "api_url": "https://api.somewhere",
+    "oauth_url": "https://uaa.somewhere",
+    "client_id": "clientid",
+    "client_secret": "secret"
+  }
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"code.cloudfoundry.org/route-registrar/healthchecker"
 	"code.cloudfoundry.org/route-registrar/messagebus"
 	"code.cloudfoundry.org/route-registrar/registrar"
+	"code.cloudfoundry.org/route-registrar/routingapi"
 	"github.com/tedsuo/ifrit"
 )
 
@@ -49,7 +50,10 @@ func main() {
 	logger.Info("creating nats connection")
 	messageBus := messagebus.NewMessageBus(logger)
 
-	r := registrar.NewRegistrar(*c, hc, logger, messageBus)
+	logger.Info("creating routing API connection")
+	routingAPI := routingapi.NewRoutingAPI(logger)
+
+	r := registrar.NewRegistrar(*c, hc, logger, messageBus, routingAPI)
 
 	if *pidfile != "" {
 		pid := strconv.Itoa(os.Getpid())

--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 		fakeHealthChecker = new(healthchecker_fakes.FakeHealthChecker)
 		fakeMessageBus = new(messagebus_fakes.FakeMessageBus)
 
-		r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+		r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 	})
 
 	It("connects to messagebus", func() {
@@ -281,14 +281,14 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 				Timeout:    timeout,
 			}
 
-			r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+			r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 		})
 
 		Context("and the healthcheck succeeds", func() {
 			BeforeEach(func() {
 				fakeHealthChecker.CheckReturns(true, nil)
 
-				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 			})
 
 			It("registers routes", func() {
@@ -357,7 +357,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 			BeforeEach(func() {
 				fakeHealthChecker.CheckReturns(false, nil)
 
-				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 			})
 
 			It("unregisters routes", func() {
@@ -429,7 +429,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 				healthcheckErr = fmt.Errorf("boom")
 				fakeHealthChecker.CheckReturns(true, healthcheckErr)
 
-				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 			})
 
 			It("unregisters routes", func() {
@@ -501,7 +501,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 					return true, nil
 				}
 
-				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus)
+				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
 			})
 
 			It("returns instantly upon interrupt", func() {

--- a/routingapi/api.go
+++ b/routingapi/api.go
@@ -1,0 +1,144 @@
+package routingapi
+
+import (
+	"code.cloudfoundry.org/route-registrar/config"
+	"fmt"
+	"time"
+
+	uaaclient "code.cloudfoundry.org/uaa-go-client"
+	uaaconfig "code.cloudfoundry.org/uaa-go-client/config"
+
+	"code.cloudfoundry.org/routing-api/models"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/routing-api"
+)
+
+type RoutingAPI interface {
+	Init(api_config config.RoutingAPI) error
+	RegisterRoute(route config.Route) error
+	UnregisterRoute(route config.Route) error
+	Close()
+}
+
+type apiState struct {
+	logger          lager.Logger
+	uaaClient       uaaclient.Client
+	apiClient       routing_api.Client
+	routerGroupGUID map[string]string
+}
+
+func NewRoutingAPI(logger lager.Logger) RoutingAPI {
+	return &apiState{
+		logger:          logger,
+		routerGroupGUID: make(map[string]string),
+	}
+}
+
+func buildOAuthConfig(config config.RoutingAPI) *uaaconfig.Config {
+
+	return &uaaconfig.Config{
+		UaaEndpoint:           config.OAuthURL,
+		SkipVerification:      config.SkipCertValidation,
+		ClientName:            config.ClientID,
+		ClientSecret:          config.ClientSecret,
+		MaxNumberOfRetries:    3,
+		RetryInterval:         500 * time.Millisecond,
+		ExpirationBufferInSec: 30,
+		CACerts:               config.CACerts,
+	}
+}
+
+func (a *apiState) Init(config config.RoutingAPI) error {
+	cfg := buildOAuthConfig(config)
+	clk := clock.NewClock()
+
+	uaaClient, err := uaaclient.NewClient(a.logger, cfg, clk)
+	if err != nil {
+		return err
+	}
+
+	a.uaaClient = uaaClient
+	a.apiClient = routing_api.NewClient(config.APIURL, config.SkipCertValidation)
+
+	return nil
+}
+
+func (a *apiState) refreshToken() error {
+	token, err := a.uaaClient.FetchToken(false)
+	if err != nil {
+		return err
+	}
+
+	a.apiClient.SetToken(token.AccessToken)
+	return nil
+}
+
+func (a *apiState) getRouterGroupGUID(name string) (string, error) {
+	guid, exists := a.routerGroupGUID[name]
+	if exists {
+		return guid, nil
+	}
+
+	routerGroup, err := a.apiClient.RouterGroupWithName(name)
+	if err != nil {
+		return "", err
+	}
+	if routerGroup.Guid == "" {
+		return "", fmt.Errorf("Router group '%s' not found", name)
+	}
+
+	a.logger.Info("Mapped new router group", lager.Data{
+		"router_group": name,
+		"guid":         routerGroup.Guid})
+
+	a.routerGroupGUID[name] = routerGroup.Guid
+	return routerGroup.Guid, nil
+}
+
+func (a *apiState) makeTcpRouteMapping(route config.Route) (models.TcpRouteMapping, error) {
+	routerGroupGUID, err := a.getRouterGroupGUID(route.RouterGroup)
+	if err != nil {
+		return models.TcpRouteMapping{}, err
+	}
+
+	return models.NewTcpRouteMapping(
+		routerGroupGUID,
+		uint16(*route.Port),
+		route.BackendIP,
+		uint16(route.BackendPort),
+		int(route.RegistrationInterval.Seconds())), nil
+}
+
+func (a *apiState) RegisterRoute(route config.Route) error {
+	err := a.refreshToken()
+	if err != nil {
+		return err
+	}
+
+	routeMapping, err := a.makeTcpRouteMapping(route)
+	if err != nil {
+		return err
+	}
+
+	return a.apiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{
+		routeMapping})
+}
+
+func (a *apiState) UnregisterRoute(route config.Route) error {
+	err := a.refreshToken()
+	if err != nil {
+		return err
+	}
+
+	routeMapping, err := a.makeTcpRouteMapping(route)
+	if err != nil {
+		return err
+	}
+
+	return a.apiClient.DeleteTcpRouteMappings([]models.TcpRouteMapping{routeMapping})
+}
+
+func (a *apiState) Close() {
+}


### PR DESCRIPTION
This adds basic support for registration of TCP routes by route-registrar.  The way it is implemented nothing changes/breaks if TCP routing is not desired or configured.

To get started, the configuration file should include an additional `routing_api` section such as this one:
```
  "routing_api": {
    "api_url": "https://api.somewhere",
    "oauth_url": "https://uaa.somewhere",
    "client_id": "clientid",
    "client_secret": "secret",
    "ca_certs": "",
    "skip_cert_validation": true
  }
```

TCP routes can then be configured in the exact same way HTTP routes are configured, for example:
```
    {
        "type": "tcp",
        "port": 5000,
        "backend_ip": "10.0.1.1",
        "backend_port": 15000,
        "router_group": "default-tcp",
        "registration_interval": "10s"
    }
```

TCP routes are identified by having a `type` field with a `tcp` value.  The `port` field is interpreted as the external port, while `backend_ip` and `backend_port` provide the backend mapping.  The `router_group` field is also required and gets mapped to the appropriate GUID at runtime.  Registration interval and optionally health checks work the same way as HTTP.

It is possible to define only TCP routes, only HTTP routes or both.  If no HTTP routes are used, `message_bus_servers` is not required and no connection is made.  If no TCP routes are used, the same applies to `routing_api`.  I'm not sure about the Routing API roadmap but it may eventually make sense to converge everything to use only that.