### PR TITLE
feat: Implement protocol field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type RouteSchema struct {
 	Type                 string             `json:"type"`
 	Name                 string             `json:"name"`
 	Port                 *int               `json:"port"`
+	Protocol             string             `json:"protocol"`
 	SniPort              *int               `json:"sni_port"`
 	TLSPort              *int               `json:"tls_port"`
 	Tags                 map[string]string  `json:"tags"`
@@ -115,6 +116,7 @@ type Route struct {
 	Type                 string
 	Name                 string
 	Port                 *int
+	Protocol             string
 	TLSPort              *int
 	Tags                 map[string]string
 	URIs                 []string
@@ -267,6 +269,10 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 		}
 	}
 
+	if r.Protocol != "" && r.Protocol != "http1" && r.Protocol != "http2" {
+		errors.Add(fmt.Errorf("unknown protocol: %s", r.Protocol))
+	}
+
 	registrationInterval, err := parseRegistrationInterval(r.RegistrationInterval)
 	if err != nil {
 		errors.Add(err)
@@ -288,6 +294,7 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 		Type:                 r.Type,
 		Name:                 r.Name,
 		Port:                 r.Port,
+		Protocol:             r.Protocol,
 		TLSPort:              r.TLSPort,
 		Tags:                 r.Tags,
 		URIs:                 r.URIs,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,9 @@ var _ = Describe("Config", func() {
 		backendPort     int
 		sniExternalPort int
 		sniPort         int
+
+		protocolH1 string
+		protocolH2 string
 	)
 
 	BeforeEach(func() {
@@ -52,6 +55,8 @@ var _ = Describe("Config", func() {
 		backendPort = 15000
 		sniExternalPort = 16000
 		sniPort = 17000
+		protocolH1 = "http1"
+		protocolH2 = "http2"
 
 		configSchema = config.ConfigSchema{
 			MessageBusServers: []config.MessageBusServerSchema{
@@ -83,6 +88,7 @@ var _ = Describe("Config", func() {
 				{
 					Name:                 routeName1,
 					TLSPort:              &port1,
+					Protocol:             protocolH1,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
 					ServerCertDomainSAN:  "my.internal.cert",
@@ -91,6 +97,7 @@ var _ = Describe("Config", func() {
 					Name:                 routeName2,
 					Port:                 &port0,
 					TLSPort:              &port1,
+					Protocol:             protocolH2,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
 					ServerCertDomainSAN:  "my.internal.cert",
@@ -200,6 +207,7 @@ var _ = Describe("Config", func() {
 					{
 						Name:                 routeName1,
 						TLSPort:              &port1,
+						Protocol:             protocolH1,
 						RegistrationInterval: registrationInterval1,
 						URIs:                 configSchema.Routes[1].URIs,
 						ServerCertDomainSAN:  "my.internal.cert",
@@ -208,6 +216,7 @@ var _ = Describe("Config", func() {
 						Name:                 routeName2,
 						Port:                 &port0,
 						TLSPort:              &port1,
+						Protocol:             protocolH2,
 						RegistrationInterval: registrationInterval1,
 						URIs:                 configSchema.Routes[1].URIs,
 						ServerCertDomainSAN:  "my.internal.cert",
@@ -541,6 +550,22 @@ var _ = Describe("Config", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(`route "route-0"`))
 					Expect(err.Error()).To(ContainSubstring("invalid port: -1"))
+				})
+			})
+		})
+
+		Describe("on route protocol", func() {
+			Context("when an unknown protocol is provided", func() {
+				BeforeEach(func() {
+					configSchema.Routes[0].Protocol = "abcd"
+				})
+
+				It("returns an error", func() {
+					c, err := configSchema.ToConfig()
+					Expect(c).To(BeNil())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(`route "route-0"`))
+					Expect(err.Error()).To(ContainSubstring("unknown protocol"))
 				})
 			})
 		})

--- a/example_config/example.json
+++ b/example_config/example.json
@@ -12,6 +12,7 @@
     {
       "name": "route-1",
       "tls_port": 3001,
+      "protocol": "http1",
       "uris": [
         "my-other-app.my-domain.com"
       ],
@@ -22,6 +23,7 @@
       "name": "route-2",
       "port": 3000,
       "tls_port": 3001,
+      "protocol": "http2",
       "uris": [
         "my-other-app.my-domain.com"
       ],

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -31,6 +31,7 @@ type msgBus struct {
 type Message struct {
 	URIs                []string          `json:"uris"`
 	Host                string            `json:"host"`
+	Protocol            string            `json:"protocol,omitempty"`
 	Port                *int              `json:"port,omitempty"`
 	TLSPort             *int              `json:"tls_port,omitempty"`
 	Tags                map[string]string `json:"tags"`
@@ -105,6 +106,7 @@ func (m msgBus) SendMessage(subject string, host string, route config.Route, pri
 		URIs:                route.URIs,
 		Host:                host,
 		Port:                route.Port,
+		Protocol:            route.Protocol,
 		TLSPort:             route.TLSPort,
 		Tags:                route.Tags,
 		RouteServiceUrl:     route.RouteServiceUrl,

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -286,6 +286,7 @@ var _ = Describe("Messagebus test Suite", func() {
 
 			Expect(registryMessage.URIs).To(Equal(expectedRegistryMessage.URIs))
 			Expect(registryMessage.Port).To(Equal(expectedRegistryMessage.Port))
+			Expect(registryMessage.Protocol).To(BeEmpty())
 			Expect(registryMessage.RouteServiceUrl).To(Equal(expectedRegistryMessage.RouteServiceUrl))
 			Expect(registryMessage.Tags).To(Equal(expectedRegistryMessage.Tags))
 		})
@@ -302,6 +303,76 @@ var _ = Describe("Messagebus test Suite", func() {
 				err := messageBus.SendMessage(topic, host, route, privateInstanceId)
 				Expect(err).Should(HaveOccurred())
 			})
+		})
+	})
+
+	Describe("SendMessage for h2 route", func() {
+		const (
+			topic             = "router.registrar"
+			host              = "some_host"
+			privateInstanceId = "some_id"
+		)
+
+		var (
+			route config.Route
+		)
+
+		BeforeEach(func() {
+			err := messageBus.Connect(messageBusServers, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			port := 12345
+
+			route = config.Route{
+				Name:                "some_name",
+				Port:                &port,
+				TLSPort:             &port,
+				Protocol:            "http2",
+				URIs:                []string{"uri1", "uri2"},
+				RouteServiceUrl:     "https://rs.example.com",
+				Tags:                map[string]string{"tag1": "val1", "tag2": "val2"},
+				ServerCertDomainSAN: "cf.cert.internal",
+			}
+		})
+
+		It("send messages", func() {
+			registered := make(chan string)
+			testSpyClient.Subscribe(topic, func(msg *nats.Msg) {
+				registered <- string(msg.Data)
+			})
+
+			// Wait for the nats library to register our callback.
+			// We use a sleep because there's no way to know that the callback was
+			// registered successfully (e.g. they don't provide a channel)
+			time.Sleep(20 * time.Millisecond)
+
+			err := messageBus.SendMessage(topic, host, route, privateInstanceId)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert that we got the right message
+			var receivedMessage string
+			Eventually(registered, 2).Should(Receive(&receivedMessage))
+
+			expectedRegistryMessage := messagebus.Message{
+				URIs:                route.URIs,
+				Host:                host,
+				Port:                route.Port,
+				Protocol:            route.Protocol,
+				TLSPort:             route.TLSPort,
+				RouteServiceUrl:     route.RouteServiceUrl,
+				Tags:                route.Tags,
+				ServerCertDomainSAN: "cf.cert.internal",
+			}
+
+			var registryMessage messagebus.Message
+			err = json.Unmarshal([]byte(receivedMessage), &registryMessage)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(registryMessage.URIs).To(Equal(expectedRegistryMessage.URIs))
+			Expect(registryMessage.Port).To(Equal(expectedRegistryMessage.Port))
+			Expect(registryMessage.Protocol).To(Equal(expectedRegistryMessage.Protocol))
+			Expect(registryMessage.RouteServiceUrl).To(Equal(expectedRegistryMessage.RouteServiceUrl))
+			Expect(registryMessage.Tags).To(Equal(expectedRegistryMessage.Tags))
 		})
 	})
 })


### PR DESCRIPTION
- Related to issue: https://github.com/cloudfoundry/routing-release/issues/320.
- The PR adds an additional field to the route configuration called 'protocol' which can be set to 'http1' or 'http2' or left empty to support http2 routes. The field is also included in the route that is announced to gorouter.
- Additional tests for the new field.