### PR TITLE
Use BeNil() since bump to gomega 1.33.0

### DIFF
--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -616,7 +616,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 				time.Sleep(1500 * time.Millisecond)
 
 				close(signals)
-				Eventually(runStatus, 100*time.Millisecond).Should(Receive(nil))
+				Eventually(runStatus, 100*time.Millisecond).Should(Receive(BeNil()))
 			})
 		})
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Context: https://github.com/onsi/gomega/releases/tag/v1.33.0


Backward Compatibility
---------------
Breaking Change? **No**
