### PR TITLE
feat: Implement loadbalancing algo per route

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please report all issues and feature requests in [cloudfoundry/routing-release](
         "timeout": "HEALTH_CHECK_TIMEOUT"
       },
       "options": {
-        "lb_algorithm": "least-connections"
+        "lb_algo": "least-connection"
       }
     }
   ]
@@ -130,7 +130,7 @@ The following applies:
 
 ### Options
 Custom per-route options can be defined and applied to specific routes exclusively.
-- `lb_algorithm` enables the selection of a load balancing algorithm for routing incoming requests to backend. It possible to choose between `round-robin` and `least-connections`. In cases where this option is not specified, the default algorithm `round-robin` is applied.
+- `lb_algo` enables the selection of a load balancing algorithm for routing incoming requests to the backend. It is possible to choose between `round-robin` and `least-connection`. In cases where this option is not specified, the algorithm [defined by the platform operator](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L101) is applied.
 
 ## BOSH release
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Please report all issues and feature requests in [cloudfoundry/routing-release](
         "name": "HEALTH_CHECK_NAME",
         "script_path": "/path/to/check/executable",
         "timeout": "HEALTH_CHECK_TIMEOUT"
+      },
+      "options": {
+        "lb_algorithm": "least-connections"
       }
     }
   ]
@@ -86,6 +89,7 @@ Please report all issues and feature requests in [cloudfoundry/routing-release](
     - `route_service_url` is optional. When provided, Gorouter will proxy
       requests received for the `uris` above to this address.
     - `health_check` is optional and explained in more detail below.
+    - `options` is optional and explained in more detail below.
 
 1. Run route-registrar binaries using the following command
   ```bash
@@ -123,6 +127,10 @@ The following applies:
   half the `registration_interval`. If the executable does not terminate within
   the timeout, it is forcibly terminated (with `SIGKILL`) and the routes are
   deregistered.
+
+### Options
+Custom per-route options can be defined and applied to specific routes exclusively.
+- `lb_algorithm` enables the selection of a load balancing algorithm for routing incoming requests to backend. It possible to choose between `round-robin` and `least-connections`. In cases where this option is not specified, the default algorithm `round-robin` is applied.
 
 ## BOSH release
 

--- a/example_config/example.json
+++ b/example_config/example.json
@@ -17,7 +17,7 @@
         "my-other-app.my-domain.com"
       ],
       "options": {
-        "lb_algorithm": "least-connections"
+        "lb_algo": "least-connection"
       },
       "registration_interval": "10s",
       "server_cert_domain_san": "my.internal.cert"

--- a/example_config/example.json
+++ b/example_config/example.json
@@ -16,6 +16,9 @@
       "uris": [
         "my-other-app.my-domain.com"
       ],
+      "options": {
+        "lb_algorithm": "least-connections"
+      },
       "registration_interval": "10s",
       "server_cert_domain_san": "my.internal.cert"
     },

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -10,17 +10,13 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 
 	tls_helpers "code.cloudfoundry.org/cf-routing-test-helpers/tls"
-	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/route-registrar/config"
 	"code.cloudfoundry.org/route-registrar/messagebus"
 	"code.cloudfoundry.org/tlsconfig"
-	"github.com/nats-io/nats.go"
 )
 
 var _ = Describe("Messagebus test Suite", func() {
@@ -405,7 +401,7 @@ var _ = Describe("Messagebus test Suite", func() {
 			}
 		})
 
-		It("send messages", func() {
+		It("sends messages", func() {
 			registered := make(chan string)
 			testSpyClient.Subscribe(topic, func(msg *nats.Msg) {
 				registered <- string(msg.Data)
@@ -429,6 +425,7 @@ var _ = Describe("Messagebus test Suite", func() {
 				TLSPort:             route.TLSPort,
 				ServerCertDomainSAN: "cf.cert.internal",
 				AvailabilityZone:    "some-az",
+				Options:             map[string]string{"lb_algo": string(route.Options.LoadBalancingAlgorithm)},
 			}
 
 			var registryMessage messagebus.Message
@@ -439,9 +436,7 @@ var _ = Describe("Messagebus test Suite", func() {
 			Expect(registryMessage.Protocol).To(BeEmpty())
 			Expect(registryMessage.AvailabilityZone).To(Equal(expectedRegistryMessage.AvailabilityZone))
 
-			v, ok := registryMessage.Options[messagebus.LoadBalancingAlgorithm]
-			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal(string(route.Options.LoadBalancingAlgorithm)))
+			Expect(registryMessage.Options).To(Equal(expectedRegistryMessage.Options))
 		})
 
 		Context("when the connection is already closed", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Implement support of custom per-route option `load balancing algorithm` in route-registrar. It possible to choose between `round-robin` and `least-connections`.
- Change according to [RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)



Backward Compatibility
---------------
Breaking Change? **No**

