### PR TITLE
Revert "Update to use newer signature for NewTcpRouteMapping function…

### DIFF
--- a/integration/tcp_route_registration_test.go
+++ b/integration/tcp_route_registration_test.go
@@ -58,8 +58,6 @@ var _ = Describe("TCP Route Registration", func() {
 				ghttp.VerifyJSON(`[{
 					"router_group_guid":"router-group-guid",
 					"backend_port":1234,
-					"backend_tls_port":0,
-					"instance_id": "",
 					"backend_ip":"127.0.0.1",
 					"port":5678,
 					"modification_tag":{

--- a/routingapi/api.go
+++ b/routingapi/api.go
@@ -82,17 +82,13 @@ func (r *RoutingAPI) makeTcpRouteMapping(route config.Route) (models.TcpRouteMap
 
 	r.logger.Info("Creating mapping", lager.Data{})
 
-	return models.NewTcpRouteMapping(
+	return models.NewSniTcpRouteMapping(
 		routerGroupGUID,
 		uint16(*route.ExternalPort),
+		nilIfEmpty(&route.ServerCertDomainSAN),
 		route.Host,
 		uint16(*route.Port),
-		0,
-		"",
-		nilIfEmpty(&route.ServerCertDomainSAN),
-		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL),
-		models.ModificationTag{},
-	), nil
+		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL)), nil
 }
 
 const TTL_BUFFER float64 = 2.1

--- a/routingapi/routingapi_test.go
+++ b/routingapi/routingapi_test.go
@@ -18,10 +18,6 @@ import (
 	fakeuaa "code.cloudfoundry.org/route-registrar/routingapi/routingapifakes"
 )
 
-func pointerToInt(i uint16) *uint16 {
-	return &i
-}
-
 var _ = Describe("Routing API", func() {
 	var (
 		client    *fake_routing_api.FakeClient
@@ -81,9 +77,6 @@ var _ = Describe("Routing API", func() {
 					HostPort:        1234,
 					ExternalPort:    5678,
 					HostIP:          "myhost",
-					HostTLSPort:     pointerToInt(0),
-					SniHostname:     nil,
-					InstanceId:      "",
 					TTL:             &expectedTTL,
 				}}
 				Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -108,9 +101,6 @@ var _ = Describe("Routing API", func() {
 						HostPort:        1234,
 						ExternalPort:    5678,
 						HostIP:          "myhost",
-						HostTLSPort:     pointerToInt(0),
-						SniHostname:     nil,
-						InstanceId:      "",
 						TTL:             &expectedTTL,
 					}}
 					Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -217,9 +207,6 @@ var _ = Describe("Routing API", func() {
 					ExternalPort:    5678,
 					HostIP:          "myhost",
 					TTL:             &expectedTTL,
-					HostTLSPort:     pointerToInt(0),
-					SniHostname:     nil,
-					InstanceId:      "",
 				}}
 
 				Expect(client.DeleteTcpRouteMappingsCallCount()).To(Equal(1))


### PR DESCRIPTION
… (#42)"

This reverts commit ad93972994c84af51dde3c3ed398713f6bd177c7.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
