### PR TITLE
Revert "Revert "Update to use newer signature for NewTcpRouteMapping …

### DIFF
--- a/integration/tcp_route_registration_test.go
+++ b/integration/tcp_route_registration_test.go
@@ -58,6 +58,8 @@ var _ = Describe("TCP Route Registration", func() {
 				ghttp.VerifyJSON(`[{
 					"router_group_guid":"router-group-guid",
 					"backend_port":1234,
+					"backend_tls_port":0,
+					"instance_id": "",
 					"backend_ip":"127.0.0.1",
 					"port":5678,
 					"modification_tag":{

--- a/routingapi/api.go
+++ b/routingapi/api.go
@@ -82,13 +82,17 @@ func (r *RoutingAPI) makeTcpRouteMapping(route config.Route) (models.TcpRouteMap
 
 	r.logger.Info("Creating mapping", lager.Data{})
 
-	return models.NewSniTcpRouteMapping(
+	return models.NewTcpRouteMapping(
 		routerGroupGUID,
 		uint16(*route.ExternalPort),
-		nilIfEmpty(&route.ServerCertDomainSAN),
 		route.Host,
 		uint16(*route.Port),
-		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL)), nil
+		0,
+		"",
+		nilIfEmpty(&route.ServerCertDomainSAN),
+		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL),
+		models.ModificationTag{},
+	), nil
 }
 
 const TTL_BUFFER float64 = 2.1

--- a/routingapi/routingapi_test.go
+++ b/routingapi/routingapi_test.go
@@ -18,6 +18,10 @@ import (
 	fakeuaa "code.cloudfoundry.org/route-registrar/routingapi/routingapifakes"
 )
 
+func pointerToInt(i uint16) *uint16 {
+	return &i
+}
+
 var _ = Describe("Routing API", func() {
 	var (
 		client    *fake_routing_api.FakeClient
@@ -77,6 +81,9 @@ var _ = Describe("Routing API", func() {
 					HostPort:        1234,
 					ExternalPort:    5678,
 					HostIP:          "myhost",
+					HostTLSPort:     pointerToInt(0),
+					SniHostname:     nil,
+					InstanceId:      "",
 					TTL:             &expectedTTL,
 				}}
 				Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -101,6 +108,9 @@ var _ = Describe("Routing API", func() {
 						HostPort:        1234,
 						ExternalPort:    5678,
 						HostIP:          "myhost",
+						HostTLSPort:     pointerToInt(0),
+						SniHostname:     nil,
+						InstanceId:      "",
 						TTL:             &expectedTTL,
 					}}
 					Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -207,6 +217,9 @@ var _ = Describe("Routing API", func() {
 					ExternalPort:    5678,
 					HostIP:          "myhost",
 					TTL:             &expectedTTL,
+					HostTLSPort:     pointerToInt(0),
+					SniHostname:     nil,
+					InstanceId:      "",
 				}}
 
 				Expect(client.DeleteTcpRouteMappingsCallCount()).To(Equal(1))


### PR DESCRIPTION
…function (#42)" (#44)"

This reverts commit 0ebd98934c2b24c651a8bcccafd331d8ff8df37d.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
Bring back reverted changes


Backward Compatibility
---------------
Breaking Change? **No**
