### PR TITLE
Unregister limit

### DIFF
--- a/example_config/example.json
+++ b/example_config/example.json
@@ -75,5 +75,6 @@
     "key_path": "key-path",
     "ca_path": "ca-path"
   },
-  "availability_zone": "some-zone"
+  "availability_zone": "some-zone",
+  "unregistration_message_limit": 5
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 		logger.Fatal("error parsing file: %s\n", err)
 	}
 
-	c, err := configSchema.ToConfig()
+	c, err := configSchema.ParseSchemaAndSetDefaultsToConfig()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 				KeyPath:  "should-not-be-used",
 				CAPath:   "should-not-be-used",
 			},
+			UnregistrationMessageLimit: 5,
 		}
 
 		signals = make(chan os.Signal, 1)
@@ -519,6 +520,318 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 
 					Expect(returned).To(Equal(err))
 				})
+			})
+		})
+
+		Context("when the healthcheck keeps failing", func() {
+			Context("when there is one route with a failing endpoint", func() {
+				BeforeEach(func() {
+					timeout := 100 * time.Millisecond
+					registrationInterval := 100 * time.Millisecond
+					port := 8080
+					rrConfig.Routes = []config.Route{
+						{
+							Name: "my route 1",
+							Port: &port,
+							URIs: []string{
+								"my uri 1.1",
+							},
+							Tags: map[string]string{
+								"tag1.1": "value1.1",
+								"tag1.2": "value1.2",
+							},
+							RegistrationInterval: registrationInterval,
+							HealthCheck: &config.HealthCheck{
+								Name:       "My Healthcheck process",
+								ScriptPath: "pass",
+								Timeout:    timeout,
+							},
+						},
+					}
+
+					fakeHealthChecker.CheckReturns(false, nil)
+					r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
+				})
+
+				It("only sends five unregistration messages per route", func() {
+					runStatus := make(chan error)
+					go func() {
+						runStatus <- r.Run(signals, ready)
+					}()
+					<-ready
+
+					Eventually(fakeMessageBus.SendMessageCallCount, 3).Should(Equal(5))
+
+					for i := 0; i < 5; i++ {
+						subject, host, route, privateInstanceId := fakeMessageBus.SendMessageArgsForCall(i)
+						Expect(subject).To(Equal("router.unregister"))
+						Expect(host).To(Equal(rrConfig.Host))
+						Expect(route.Name).To(Equal(rrConfig.Routes[0].Name))
+						Expect(route.URIs).To(Equal(rrConfig.Routes[0].URIs))
+						Expect(route.Port).To(Equal(rrConfig.Routes[0].Port))
+						Expect(privateInstanceId).NotTo(Equal(""))
+					}
+
+					Consistently(fakeMessageBus.SendMessageCallCount, 3).Should(Equal(5))
+				})
+			})
+
+			Context("when there are multiple routes with failing endpoints", func() {
+				var (
+					route1Name string
+					route2Name string
+				)
+
+				BeforeEach(func() {
+					timeout := 100 * time.Millisecond
+					registrationInterval := 100 * time.Millisecond
+					port := 8080
+					route1Name = "my route 1"
+					route2Name = "my route 2"
+					rrConfig.Routes = []config.Route{
+						{
+							Name: route1Name,
+							Port: &port,
+							URIs: []string{
+								"my uri 1.1",
+							},
+							Tags: map[string]string{
+								"tag1.1": "value1.1",
+								"tag1.2": "value1.2",
+							},
+							RegistrationInterval: registrationInterval,
+							HealthCheck: &config.HealthCheck{
+								Name:       "My Healthcheck process",
+								ScriptPath: "pass",
+								Timeout:    timeout,
+							},
+						},
+						{
+							Name: route2Name,
+							Port: &port,
+							URIs: []string{
+								"my uri 1.1",
+							},
+							Tags: map[string]string{
+								"tag1.1": "value1.1",
+								"tag1.2": "value1.2",
+							},
+							RegistrationInterval: registrationInterval,
+							HealthCheck: &config.HealthCheck{
+								Name:       "My Healthcheck process",
+								ScriptPath: "fail",
+								Timeout:    timeout,
+							},
+						},
+					}
+
+					fakeHealthChecker.CheckReturns(false, nil)
+					r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
+				})
+
+				It("sends five registration messages for each route", func() {
+					runStatus := make(chan error)
+					go func() {
+						runStatus <- r.Run(signals, ready)
+					}()
+					<-ready
+
+					Eventually(fakeMessageBus.SendMessageCallCount, 3).Should(Equal(10))
+
+					route1Counter := 0
+					route2Counter := 0
+
+					for i := 0; i < 10; i++ {
+						subject, _, route, _ := fakeMessageBus.SendMessageArgsForCall(i)
+						Expect(subject).To(Equal("router.unregister"))
+
+						if route.Name == route1Name {
+							route1Counter++
+						}
+
+						if route.Name == route2Name {
+							route2Counter++
+						}
+					}
+
+					Expect(route1Counter).To(Equal(5))
+					Expect(route2Counter).To(Equal(5))
+					Consistently(fakeMessageBus.SendMessageCallCount, 3).Should(Equal(10))
+				})
+			})
+			Context("when one route has a failing healthcheck and another route has as passing healthcheck", func() {
+				var (
+					route1Name string
+					route2Name string
+				)
+
+				BeforeEach(func() {
+					timeout := 100 * time.Millisecond
+					registrationInterval := 100 * time.Millisecond
+					port := 8080
+					route1Name = "my route 1"
+					route2Name = "my route 2"
+					rrConfig.Routes = []config.Route{
+						{
+							Name: route1Name,
+							Port: &port,
+							URIs: []string{
+								"my uri 1.1",
+							},
+							Tags: map[string]string{
+								"tag1.1": "value1.1",
+								"tag1.2": "value1.2",
+							},
+							RegistrationInterval: registrationInterval,
+							HealthCheck: &config.HealthCheck{
+								Name:       "My Healthcheck process",
+								ScriptPath: "pass",
+								Timeout:    timeout,
+							},
+						},
+						{
+							Name: route2Name,
+							Port: &port,
+							URIs: []string{
+								"my uri 1.1",
+							},
+							Tags: map[string]string{
+								"tag1.1": "value1.1",
+								"tag1.2": "value1.2",
+							},
+							RegistrationInterval: registrationInterval,
+							HealthCheck: &config.HealthCheck{
+								Name:       "My Healthcheck process",
+								ScriptPath: "fail",
+								Timeout:    timeout,
+							},
+						},
+					}
+
+					fakeHealthChecker.CheckStub = func(cr commandrunner.Runner, path string, timeout time.Duration) (bool, error) {
+						if path == "pass" {
+							return true, nil
+						}
+						return false, errors.New("oh no I failed")
+					}
+
+					r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
+				})
+
+				It("only sends five unregistration messages for the failing app", func() {
+					runStatus := make(chan error)
+					go func() {
+						runStatus <- r.Run(signals, ready)
+					}()
+					<-ready
+
+					Eventually(fakeMessageBus.SendMessageCallCount, 3).Should(BeNumerically(">", 15))
+
+					route2Counter := 0 // failing app
+
+					for i := 0; i < 15; i++ {
+						subject, _, route, _ := fakeMessageBus.SendMessageArgsForCall(i)
+
+						if route.Name == route1Name {
+							Expect(subject).To(Equal("router.register"))
+						}
+
+						if route.Name == route2Name {
+							Expect(subject).To(Equal("router.unregister"))
+							route2Counter++
+						}
+					}
+
+					Expect(route2Counter).To(Equal(5))
+				})
+			})
+		})
+
+		Context("when a route is healthy, then becomes unhealthy, then healthy, and then unhealthy again", func() {
+			var (
+				routeName  string
+				runCounter int
+			)
+
+			BeforeEach(func() {
+				timeout := 100 * time.Millisecond
+				registrationInterval := 100 * time.Millisecond
+				port := 8080
+				routeName = "my route 1"
+				rrConfig.Routes = []config.Route{
+					{
+						Name: routeName,
+						Port: &port,
+						URIs: []string{
+							"my uri 1.1",
+						},
+						Tags: map[string]string{
+							"tag1.1": "value1.1",
+							"tag1.2": "value1.2",
+						},
+						RegistrationInterval: registrationInterval,
+						HealthCheck: &config.HealthCheck{
+							Name:       "My Healthcheck process",
+							ScriptPath: "fail->pass->fail",
+							Timeout:    timeout,
+						},
+					},
+				}
+
+				runCounter = 0
+
+				fakeHealthChecker.CheckStub = func(
+					runner commandrunner.Runner,
+					path string,
+					timeout time.Duration,
+				) (bool, error) {
+					runCounter++
+					if runCounter <= 5 {
+						return true, nil
+					}
+
+					if runCounter <= 10 {
+						return false, errors.New("some failure")
+					}
+
+					if runCounter <= 15 {
+						return true, nil
+					}
+
+					return false, errors.New("some failure")
+				}
+
+				r = registrar.NewRegistrar(rrConfig, fakeHealthChecker, logger, fakeMessageBus, nil)
+			})
+
+			It("registers and unregisters properly as the route's health changes", func() {
+				runStatus := make(chan error)
+				go func() {
+					runStatus <- r.Run(signals, ready)
+				}()
+				<-ready
+
+				Eventually(fakeMessageBus.SendMessageCallCount, 3).Should(Equal(20))
+
+				for i := 0; i < 20; i++ {
+					subject, _, route, _ := fakeMessageBus.SendMessageArgsForCall(i)
+					Expect(route.Name).To(Equal(routeName))
+					if i < 5 {
+						Expect(subject).To(Equal("router.register"))
+						continue
+					}
+					if i < 10 {
+						Expect(subject).To(Equal("router.unregister"))
+						continue
+					}
+					if i < 15 {
+						Expect(subject).To(Equal("router.register"))
+						continue
+					}
+					if i < 20 {
+						Expect(subject).To(Equal("router.unregister"))
+					}
+				}
 			})
 		})
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- This PR is for adding a limit in route-registrar to the number of consecutive unregistration messages it will send for a bad route so that gorouter logs don't get overwhelmed with redundant messages


Backward Compatibility
---------------
Breaking Change? **No**