### PR TITLE
Update route-registrar to handle *uint16 -> int conversion for HostTL…

### DIFF
--- a/routingapi/api.go
+++ b/routingapi/api.go
@@ -87,7 +87,7 @@ func (r *RoutingAPI) makeTcpRouteMapping(route config.Route) (models.TcpRouteMap
 		uint16(*route.ExternalPort),
 		route.Host,
 		uint16(*route.Port),
-		0,
+		-1,
 		"",
 		nilIfEmpty(&route.ServerCertDomainSAN),
 		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL),

--- a/routingapi/routingapi_test.go
+++ b/routingapi/routingapi_test.go
@@ -18,10 +18,6 @@ import (
 	fakeuaa "code.cloudfoundry.org/route-registrar/routingapi/routingapifakes"
 )
 
-func pointerToInt(i uint16) *uint16 {
-	return &i
-}
-
 var _ = Describe("Routing API", func() {
 	var (
 		client    *fake_routing_api.FakeClient
@@ -81,7 +77,7 @@ var _ = Describe("Routing API", func() {
 					HostPort:        1234,
 					ExternalPort:    5678,
 					HostIP:          "myhost",
-					HostTLSPort:     pointerToInt(0),
+					HostTLSPort:     -1,
 					SniHostname:     nil,
 					InstanceId:      "",
 					TTL:             &expectedTTL,
@@ -108,7 +104,7 @@ var _ = Describe("Routing API", func() {
 						HostPort:        1234,
 						ExternalPort:    5678,
 						HostIP:          "myhost",
-						HostTLSPort:     pointerToInt(0),
+						HostTLSPort:     -1,
 						SniHostname:     nil,
 						InstanceId:      "",
 						TTL:             &expectedTTL,
@@ -217,7 +213,7 @@ var _ = Describe("Routing API", func() {
 					ExternalPort:    5678,
 					HostIP:          "myhost",
 					TTL:             &expectedTTL,
-					HostTLSPort:     pointerToInt(0),
+					HostTLSPort:     -1,
 					SniHostname:     nil,
 					InstanceId:      "",
 				}}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Convert Host TLSPort to an int to allow explicit disable of TLS


Backward Compatibility
---------------
Breaking Change? **No**