### PR TITLE
Updates route-registrar to be aware of routing-api changes for handling TCP routes using TLS

### DIFF
--- a/integration/tcp_route_registration_test.go
+++ b/integration/tcp_route_registration_test.go
@@ -58,6 +58,8 @@ var _ = Describe("TCP Route Registration", func() {
 				ghttp.VerifyJSON(`[{
 					"router_group_guid":"router-group-guid",
 					"backend_port":1234,
+					"backend_tls_port":-1,
+					"instance_id": "",
 					"backend_ip":"127.0.0.1",
 					"port":5678,
 					"modification_tag":{
@@ -71,7 +73,7 @@ var _ = Describe("TCP Route Registration", func() {
 			),
 		}
 		routingAPIServer.AppendHandlers(routingAPIResponses...)
-		routingAPIServer.SetAllowUnhandledRequests(true) //sometimes multiple creates happen
+		routingAPIServer.SetAllowUnhandledRequests(true) // sometimes multiple creates happen
 
 		oauthServer = ghttp.NewUnstartedServer()
 		oauthHandlers = []http.HandlerFunc{
@@ -104,8 +106,8 @@ var _ = Describe("TCP Route Registration", func() {
 		rootConfig.RoutingAPI.ClientPrivateKeyPath = routingAPIClientPrivateKeyPath
 		rootConfig.RoutingAPI.ServerCACertificatePath = routingAPICAFileName
 
-		var port = 1234
-		var externalPort = 5678
+		port := 1234
+		externalPort := 5678
 		routes := []config.RouteSchema{{
 			Name:                 "my-route",
 			Type:                 "tcp",
@@ -174,7 +176,8 @@ var _ = Describe("TCP Route Registration", func() {
 				}`,
 							http.Header{"Content-Type": []string{"application/json"}},
 						),
-					)}
+					),
+				}
 			})
 			It("Retries UAA token refreshes if problems were encountered", func() {
 				Eventually(session.Out).Should(gbytes.Say("error-fetching-token"))
@@ -241,7 +244,6 @@ var _ = Describe("TCP Route Registration", func() {
 			})
 		})
 	})
-
 })
 
 func registerRoute() (*gexec.Session, error) {

--- a/routingapi/api.go
+++ b/routingapi/api.go
@@ -82,13 +82,17 @@ func (r *RoutingAPI) makeTcpRouteMapping(route config.Route) (models.TcpRouteMap
 
 	r.logger.Info("Creating mapping", lager.Data{})
 
-	return models.NewSniTcpRouteMapping(
+	return models.NewTcpRouteMapping(
 		routerGroupGUID,
 		uint16(*route.ExternalPort),
-		nilIfEmpty(&route.ServerCertDomainSAN),
 		route.Host,
 		uint16(*route.Port),
-		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL)), nil
+		-1,
+		"",
+		nilIfEmpty(&route.ServerCertDomainSAN),
+		calculateTTL(route.RegistrationInterval, r.routingAPIMaxTTL),
+		models.ModificationTag{},
+	), nil
 }
 
 const TTL_BUFFER float64 = 2.1

--- a/routingapi/routingapi_test.go
+++ b/routingapi/routingapi_test.go
@@ -77,6 +77,9 @@ var _ = Describe("Routing API", func() {
 					HostPort:        1234,
 					ExternalPort:    5678,
 					HostIP:          "myhost",
+					HostTLSPort:     -1,
+					SniHostname:     nil,
+					InstanceId:      "",
 					TTL:             &expectedTTL,
 				}}
 				Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -101,6 +104,9 @@ var _ = Describe("Routing API", func() {
 						HostPort:        1234,
 						ExternalPort:    5678,
 						HostIP:          "myhost",
+						HostTLSPort:     -1,
+						SniHostname:     nil,
+						InstanceId:      "",
 						TTL:             &expectedTTL,
 					}}
 					Expect(client.UpsertTcpRouteMappingsCallCount()).To(Equal(1))
@@ -207,6 +213,9 @@ var _ = Describe("Routing API", func() {
 					ExternalPort:    5678,
 					HostIP:          "myhost",
 					TTL:             &expectedTTL,
+					HostTLSPort:     -1,
+					SniHostname:     nil,
+					InstanceId:      "",
 				}}
 
 				Expect(client.DeleteTcpRouteMappingsCallCount()).To(Equal(1))


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------


This reverts commit 9b71bdceb737691a86f543c3d588eaabaed6d245. This reverts commit f2c7bf11255bec2d1b8d4d6c7cd577bc998a33ee. This reverts commit 3a541c21da733d512f92f384ee15a4a068ba5a4e.


Backward Compatibility
---------------
Breaking Change? no
