### PR TITLE
Replace nats deprecated DefaultOptions with GetDefaultOptions()

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Main", func() {
 			),
 		}
 
-		opts := nats.DefaultOptions
+		opts := nats.GetDefaultOptions()
 		opts.Servers = servers
 
 		Eventually(func() error {
@@ -242,7 +242,7 @@ var _ = Describe("Main", func() {
 				),
 			}
 
-			tlsOpts := nats.DefaultOptions
+			tlsOpts := nats.GetDefaultOptions()
 			tlsOpts.Servers = tlsServers
 
 			spyClientTLSConfig, err := tlsconfig.Build(

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -65,7 +65,7 @@ func (m *msgBus) Connect(servers []config.MessageBusServer, tlsConfig *tls.Confi
 		natsHosts = append(natsHosts, server.Host)
 	}
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = natsServers
 	opts.TLSConfig = tlsConfig
 	opts.PingInterval = 20 * time.Second

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Messagebus test Suite", func() {
 			),
 		}
 
-		opts := nats.DefaultOptions
+		opts := nats.GetDefaultOptions()
 		opts.Servers = servers
 
 		testSpyClient, err = opts.Connect()
@@ -122,7 +122,7 @@ var _ = Describe("Messagebus test Suite", func() {
 					),
 				}
 
-				tlsOpts := nats.DefaultOptions
+				tlsOpts := nats.GetDefaultOptions()
 				tlsOpts.Servers = tlsServers
 				tlsOpts.User = "testuser"
 				tlsOpts.Password = "testpw"

--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 			),
 		}
 
-		opts := nats.DefaultOptions
+		opts := nats.GetDefaultOptions()
 		opts.Servers = servers
 
 		messageBusServer := config.MessageBusServer{


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This updates deprecated functionality. DefaultOptions field has been replaced with a GetDefaultOptions function.

Backward Compatibility
---------------
Breaking Change? **No**