### PR TITLE
Support dynamic configuration for routes

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Config", func() {
 					RegistrationInterval: registrationInterval1String,
 				},
 			},
+			DynamicConfigGlobs: []string{"/some/config/*/path1", "/some/config/*/path2"},
 			NATSmTLSConfig: config.ClientTLSConfigSchema{
 				Enabled:  true,
 				CertPath: "cert-path",
@@ -242,6 +243,7 @@ var _ = Describe("Config", func() {
 						RegistrationInterval: registrationInterval1String,
 					},
 				},
+				DynamicConfigGlobs: []string{"/some/config/*/path1", "/some/config/*/path2"},
 				NATSmTLSConfig: config.ClientTLSConfigSchema{
 					Enabled:  true,
 					CertPath: "cert-path",
@@ -319,6 +321,7 @@ var _ = Describe("Config", func() {
 						RegistrationInterval: registrationInterval1,
 					},
 				},
+				DynamicConfigGlobs: []string{"/some/config/*/path1", "/some/config/*/path2"},
 				NATSmTLSConfig: config.ClientTLSConfig{
 					Enabled:  true,
 					CertPath: "cert-path",

--- a/example_config/example.json
+++ b/example_config/example.json
@@ -75,6 +75,7 @@
     "key_path": "key-path",
     "ca_path": "ca-path"
   },
+  "dynamic_config_globs": ["/some/config/*/path1", "/some/config/*/path2"],
   "availability_zone": "some-zone",
   "unregistration_message_limit": 5
 }

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 		routingAPI = routingapi.NewRoutingAPI(logger, uaaClient, apiClient, c.RoutingAPI.MaxTTL)
 	}
 
-	r := registrar.NewRegistrar(*c, hc, logger, messageBus, routingAPI)
+	r := registrar.NewRegistrar(*c, hc, logger, messageBus, routingAPI, 10*time.Second)
 
 	if *pidfile != "" {
 		pid := strconv.Itoa(os.Getpid())

--- a/registrar/periodic_health_check_close_chans.go
+++ b/registrar/periodic_health_check_close_chans.go
@@ -1,0 +1,41 @@
+package registrar
+
+import (
+	"reflect"
+
+	"code.cloudfoundry.org/route-registrar/config"
+)
+
+type PeriodicHealthcheckCloseChans struct {
+	chans []PeriodicHealthcheckCloseChan
+}
+
+type PeriodicHealthcheckCloseChan struct {
+	route     config.Route
+	closeChan chan struct{}
+}
+
+func (p *PeriodicHealthcheckCloseChans) Add(route config.Route) chan struct{} {
+	closeChan := make(chan struct{})
+	p.chans = append(p.chans, PeriodicHealthcheckCloseChan{
+		route:     route,
+		closeChan: closeChan,
+	})
+	return closeChan
+}
+
+func (p *PeriodicHealthcheckCloseChans) CloseForRoute(route config.Route) {
+	for i, c := range p.chans {
+		if reflect.DeepEqual(c.route, route) {
+			close(c.closeChan)
+			p.chans = append(p.chans[:i], p.chans[i+1:]...)
+			return
+		}
+	}
+}
+
+func (p *PeriodicHealthcheckCloseChans) CloseAll() {
+	for _, c := range p.chans {
+		close(c.closeChan)
+	}
+}

--- a/registrar/routes_config_watcher.go
+++ b/registrar/routes_config_watcher.go
@@ -1,0 +1,153 @@
+package registrar
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/route-registrar/config"
+	"gopkg.in/yaml.v3"
+)
+
+type RoutesConfigSchema struct {
+	Routes []config.RouteSchema `json:"routes"`
+}
+
+type routesConfigWatcher struct {
+	globs               []string
+	logger              lager.Logger
+	watchInterval       time.Duration
+	discoveredRoutes    map[string][]config.Route
+	routeDiscoveredChan chan config.Route
+	routeRemovedChan    chan config.Route
+}
+
+func NewRoutesConfigWatcher(logger lager.Logger, watchInterval time.Duration, globs []string, routeDiscoveredChan chan config.Route, routeRemovedChan chan config.Route) *routesConfigWatcher {
+	return &routesConfigWatcher{
+		globs:               globs,
+		logger:              logger.Session("routes-config-watcher"),
+		watchInterval:       watchInterval,
+		routeDiscoveredChan: routeDiscoveredChan,
+		routeRemovedChan:    routeRemovedChan,
+		discoveredRoutes:    map[string][]config.Route{},
+	}
+}
+
+func (r *routesConfigWatcher) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	close(ready)
+
+	timer := time.NewTicker(r.watchInterval)
+	for {
+		select {
+		case <-timer.C:
+			err := r.discoverRoutesFromConfigFiles()
+			if err != nil {
+				r.logger.Error("failed-to-discover-config-files", err)
+				return err
+			}
+
+		case s := <-signals:
+			r.logger.Info("caught-signal", lager.Data{"signal": s})
+			return nil
+		}
+	}
+}
+
+func (r *routesConfigWatcher) discoverRoutesFromConfigFiles() error {
+	allFiles := map[string]bool{}
+
+	for _, glob := range r.globs {
+		files, err := filepath.Glob(glob)
+		if err != nil {
+			r.logger.Error("failed-to-glob-config-files", err, lager.Data{"glob": glob})
+			return err
+		}
+
+		for _, f := range files {
+			allFiles[f] = true
+
+			r.registerNewRoutesFromConfigFile(f)
+		}
+	}
+
+	for f := range r.discoveredRoutes {
+		if _, ok := allFiles[f]; !ok {
+			r.logger.Info("removing-routes-from-config-file", lager.Data{"file": f})
+			for _, route := range r.discoveredRoutes[f] {
+				r.routeRemovedChan <- route
+			}
+			delete(r.discoveredRoutes, f)
+		}
+	}
+
+	return nil
+}
+
+func (r *routesConfigWatcher) registerNewRoutesFromConfigFile(configFile string) {
+	b, err := os.ReadFile(configFile)
+	if err != nil {
+		r.logger.Error("failed-to-read-macthed-file", err)
+		return
+	}
+	var routesConfig RoutesConfigSchema
+	err = yaml.Unmarshal(b, &routesConfig)
+	if err != nil {
+		r.logger.Error("failed-to-parse-file", err)
+		return
+	}
+
+	if _, ok := r.discoveredRoutes[configFile]; !ok {
+		r.discoveredRoutes[configFile] = []config.Route{}
+	}
+
+	configRoutes := []config.Route{}
+
+	for i, routeSchema := range routesConfig.Routes {
+		route, err := config.RouteFromSchema(routeSchema, i)
+		if err != nil {
+			r.logger.Error("failed-to-parse-route", err)
+			continue
+		}
+
+		if route != nil {
+			configRoutes = append(configRoutes, *route)
+
+			if !containsRoute(r.discoveredRoutes[configFile], *route) {
+				r.discoveredRoutes[configFile] = append(r.discoveredRoutes[configFile], *route)
+				r.routeDiscoveredChan <- *route
+			}
+		}
+	}
+
+	for i, route := range r.discoveredRoutes[configFile] {
+		if !containsRoute(configRoutes, route) {
+			r.discoveredRoutes[configFile] = append(r.discoveredRoutes[configFile][:i], r.discoveredRoutes[configFile][i+1:]...)
+			r.routeRemovedChan <- route
+		}
+	}
+}
+
+func containsRoute(routes []config.Route, route config.Route) bool {
+	for _, r := range routes {
+		if reflect.DeepEqual(r, route) {
+			return true
+		}
+	}
+
+	return false
+}
+
+type noopRoutesConfigWatcher struct{}
+
+func NewNoopRoutesConfigWatcher() *noopRoutesConfigWatcher {
+	return &noopRoutesConfigWatcher{}
+}
+
+func (r *noopRoutesConfigWatcher) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	close(ready)
+
+	<-signals
+	return nil
+}

--- a/registrar/routes_config_watcher_test.go
+++ b/registrar/routes_config_watcher_test.go
@@ -1,0 +1,274 @@
+package registrar_test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/tedsuo/ifrit"
+	yaml "gopkg.in/yaml.v2"
+
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	"code.cloudfoundry.org/route-registrar/config"
+	"code.cloudfoundry.org/route-registrar/registrar"
+)
+
+var _ = Describe("RoutesConfigWatcher", func() {
+	var (
+		routesConfigWatcher ifrit.Runner
+		logger              lager.Logger
+
+		process ifrit.Process
+
+		route1Schema, route2Schema, route3Schema, route4Schema config.RouteSchema
+		route1, route2, route3, route4                         config.Route
+
+		routesDiscovered, routesRemoved chan config.Route
+		cfgDir                          string
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("Registrar test")
+		var err error
+		cfgDir, err = os.MkdirTemp(os.TempDir(), "config-")
+		Expect(err).NotTo(HaveOccurred())
+
+		glob := fmt.Sprintf("%s/config-*.yml*", cfgDir)
+		routesDiscovered = make(chan config.Route)
+		routesRemoved = make(chan config.Route)
+
+		routesConfigWatcher = registrar.NewRoutesConfigWatcher(logger, time.Second, []string{glob}, routesDiscovered, routesRemoved)
+
+		port := 8080
+		route1 = config.Route{
+			Name:                 "some-route-1",
+			Port:                 &port,
+			RegistrationInterval: time.Second,
+			URIs:                 []string{"some-route-1.apps.com"},
+			Tags:                 map[string]string{},
+		}
+		route1Schema = config.RouteSchema{
+			Name:                 "some-route-1",
+			Port:                 &port,
+			RegistrationInterval: "1s",
+			URIs:                 []string{"some-route-1.apps.com"},
+		}
+
+		route2 = config.Route{
+			Name:                 "some-route-2",
+			Port:                 &port,
+			RegistrationInterval: 2 * time.Second,
+			URIs:                 []string{"some-route-2.apps.com"},
+			Tags:                 map[string]string{},
+		}
+		route2Schema = config.RouteSchema{
+			Name:                 "some-route-2",
+			Port:                 &port,
+			RegistrationInterval: "2s",
+			URIs:                 []string{"some-route-2.apps.com"},
+		}
+
+		route3 = config.Route{
+			Name:                 "some-route-3",
+			Port:                 &port,
+			RegistrationInterval: 3 * time.Second,
+			URIs:                 []string{"some-route-3.apps.com"},
+			Tags:                 map[string]string{},
+		}
+		route3Schema = config.RouteSchema{
+			Name:                 "some-route-3",
+			Port:                 &port,
+			RegistrationInterval: "3s",
+			URIs:                 []string{"some-route-3.apps.com"},
+		}
+
+		route4 = config.Route{
+			Name:                 "some-route-4",
+			Port:                 &port,
+			RegistrationInterval: 3 * time.Second,
+			URIs:                 []string{"some-route-4.apps.com"},
+			Tags:                 map[string]string{},
+		}
+		route4Schema = config.RouteSchema{
+			Name:                 "some-route-4",
+			Port:                 &port,
+			RegistrationInterval: "3s",
+			URIs:                 []string{"some-route-4.apps.com"},
+		}
+	})
+
+	JustBeforeEach(func() {
+		process = ifrit.Background(routesConfigWatcher)
+	})
+
+	AfterEach(func() {
+		process.Signal(os.Interrupt)
+		Eventually(process.Wait(), 5*time.Second).Should(Receive())
+		os.RemoveAll(cfgDir)
+	})
+
+	Context("when directory has no files", func() {
+		It("does not discover any routes", func() {
+			Consistently(routesDiscovered).ShouldNot(Receive())
+		})
+
+		Context("when config file is created", func() {
+			It("loads all routes from the config", func() {
+				Consistently(routesDiscovered).ShouldNot(Receive())
+
+				routesBytes1, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route1Schema, route2Schema}})
+				Expect(err).NotTo(HaveOccurred())
+				cfgFile1, err := os.CreateTemp(cfgDir, "config-1.yml")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = cfgFile1.Write(routesBytes1)
+				Expect(err).NotTo(HaveOccurred())
+
+				routesBytes2, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route3Schema}})
+				Expect(err).NotTo(HaveOccurred())
+				cfgFile2, err := os.CreateTemp(cfgDir, "config-2.yml")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = cfgFile2.Write(routesBytes2)
+				Expect(err).NotTo(HaveOccurred())
+
+				var receivedRoute config.Route
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route1))
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route2))
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route3))
+			})
+		})
+	})
+
+	Context("when directory has config files already", func() {
+		var (
+			cfgFile1 *os.File
+			cfgFile2 *os.File
+		)
+
+		BeforeEach(func() {
+			var err error
+			cfgFile1, err = os.CreateTemp(cfgDir, "config-1.yml")
+			Expect(err).NotTo(HaveOccurred())
+
+			cfgFile2, err = os.CreateTemp(cfgDir, "config-2.yml")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			os.Remove(cfgFile1.Name())
+			os.Remove(cfgFile2.Name())
+		})
+
+		Context("when config files have routes", func() {
+			BeforeEach(func() {
+				routesBytes1, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route1Schema, route2Schema}})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = cfgFile1.Write(routesBytes1)
+				Expect(err).NotTo(HaveOccurred())
+
+				routesBytes2, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route3Schema}})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = cfgFile2.Write(routesBytes2)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("loads all routes from the config", func() {
+				var receivedRoute config.Route
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route1))
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route2))
+				Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+				Expect(receivedRoute).To(Equal(route3))
+			})
+
+			Context("when config file is updated and new route is added", func() {
+				It("notifies that route is discovered", func() {
+					var receivedRoute config.Route
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route1))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route2))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route3))
+
+					routesBytes2, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route3Schema, route4Schema}})
+					Expect(err).NotTo(HaveOccurred())
+					err = cfgFile2.Truncate(0)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = cfgFile2.Seek(0, 0)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = cfgFile2.Write(routesBytes2)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route4))
+				})
+			})
+
+			Context("when config file is updated and route is removed", func() {
+				It("notifies that route is removed", func() {
+					var receivedRoute config.Route
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route1))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route2))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route3))
+
+					routesBytes1, err := yaml.Marshal(registrar.RoutesConfigSchema{Routes: []config.RouteSchema{route1Schema}})
+					Expect(err).NotTo(HaveOccurred())
+					err = cfgFile1.Truncate(0)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = cfgFile1.Seek(0, 0)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = cfgFile1.Write(routesBytes1)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(routesRemoved, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route2))
+
+					Consistently(routesRemoved).ShouldNot(Receive())
+				})
+			})
+
+			Context("when config file is removed", func() {
+				It("removes routes from that config file", func() {
+					var receivedRoute config.Route
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route1))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route2))
+					Eventually(routesDiscovered, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route3))
+
+					err := os.Remove(cfgFile1.Name())
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(routesRemoved, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route1))
+
+					Eventually(routesRemoved, 2).Should(Receive(&receivedRoute))
+					Expect(receivedRoute).To(Equal(route2))
+				})
+			})
+		})
+
+		Context("when config file is in wrong format", func() {
+			BeforeEach(func() {
+				_, err := cfgFile1.Write([]byte(`invalid`))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("logs an error and continues scaning", func() {
+				Eventually(logger, 2).Should(gbytes.Say("failed-to-parse-file"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
route-registrar can be configured with glob paths that it will scan for routes to register in the format:
```
---
routes:
- name: some-route
   port: 8080
   registration_interval: 10s
   uris:
   - some.uri
 ```


Backward Compatibility
---------------
Breaking Change? **No**
