### PR TITLE
refactor: rename lb_algo to loadbalancing

### DIFF
--- a/config/assets/ports-negative.yml
+++ b/config/assets/ports-negative.yml
@@ -21,5 +21,5 @@ health_check:
   script_path: /path/to/check/executable
   timeout: 5s
 options: 
-  lb_algo: least-connection
+  loadbalancing: least-connection
 

--- a/config/assets/ports-too-high.yml
+++ b/config/assets/ports-too-high.yml
@@ -21,5 +21,5 @@ health_check:
   script_path: /path/to/check/executable
   timeout: 5s
 options: 
-  lb_algo: least-connection
+  loadbalancing: least-connection
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ type RouteSchema struct {
 }
 
 type Options struct {
-	LoadBalancingAlgorithm LoadBalancingAlgorithm `json:"lb_algo,omitempty" yaml:"lb_algo,omitempty"`
+	LoadBalancingAlgorithm LoadBalancingAlgorithm `json:"loadbalancing,omitempty" yaml:"loadbalancing,omitempty"`
 }
 
 type LoadBalancingAlgorithm string

--- a/docs/01-usage.md
+++ b/docs/01-usage.md
@@ -50,7 +50,7 @@ The route-registrar expects a configuration json file like the one below:
         "timeout": "HEALTH_CHECK_TIMEOUT"
       },
       "options": {
-        "lb_algo": "least-connection"
+        "loadbalancing": "least-connection"
       }
     }
   ]
@@ -121,5 +121,5 @@ The following applies:
 
 ## Options
 Custom per-route options can be defined and applied to specific routes exclusively.
-- `lb_algo` enables the selection of a load balancing algorithm for routing incoming requests to the backend. It is possible to choose between `round-robin` and `least-connection`. In cases where this option is not specified, the algorithm [defined by the platform operator](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L101) is applied.
+- `loadbalancing` enables the selection of a load balancing algorithm for routing incoming requests to the backend. It is possible to choose between `round-robin` and `least-connection`. In cases where this option is not specified, the algorithm [defined by the platform operator](https://github.com/cloudfoundry/routing-release/blob/develop/jobs/gorouter/spec#L101) is applied.
 

--- a/example_config/example.json
+++ b/example_config/example.json
@@ -17,7 +17,7 @@
         "my-other-app.my-domain.com"
       ],
       "options": {
-        "lb_algo": "least-connection"
+        "loadbalancing": "least-connection"
       },
       "registration_interval": "10s",
       "server_cert_domain_san": "my.internal.cert"

--- a/example_config/route.yml
+++ b/example_config/route.yml
@@ -21,5 +21,5 @@ health_check:
   script_path: /path/to/check/executable
   timeout: 5s
 options: 
-  lb_algo: least-connection
+  loadbalancing: least-connection
 

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -43,7 +43,7 @@ type Message struct {
 	Options             map[string]string `json:"options,omitempty"`
 }
 
-const LoadBalancingAlgorithm string = "lb_algo"
+const LoadBalancingAlgorithm string = "loadbalancing"
 
 func NewMessageBus(logger lager.Logger, availabilityZone string) MessageBus {
 	return &msgBus{

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -431,7 +431,7 @@ var _ = Describe("Messagebus test Suite", func() {
 				TLSPort:             route.TLSPort,
 				ServerCertDomainSAN: "cf.cert.internal",
 				AvailabilityZone:    "some-az",
-				Options:             map[string]string{"lb_algo": string(route.Options.LoadBalancingAlgorithm)},
+				Options:             map[string]string{"loadbalancing": string(route.Options.LoadBalancingAlgorithm)},
 			}
 
 			var registryMessage messagebus.Message


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Renaming the `lb_algo` property to `loadbalancing` to align with cloud controller.
The per-route options feature ([RFC 0027](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)) is not live yet, so this is not a breaking change.
See https://github.com/cloudfoundry/community/pull/1039 for an overview of all related PRs



Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
